### PR TITLE
Add python bindings for CT breakup kernel

### DIFF
--- a/src/PBESystem/CMakeLists.txt
+++ b/src/PBESystem/CMakeLists.txt
@@ -58,3 +58,6 @@ target_link_libraries(PBE ${GSL_LIBRARIES} ${Boost_LIBRARIES})
 
 set_target_properties (PBE PROPERTIES LIBRARY_OUTPUT_DIRECTORY
   "$ENV{FOAM_USER_LIBBIN}")
+
+
+add_subdirectory(bindings)

--- a/src/PBESystem/bindings/CMakeLists.txt
+++ b/src/PBESystem/bindings/CMakeLists.txt
@@ -1,0 +1,18 @@
+find_package(PythonLibs 2)
+find_package(Boost COMPONENTS python REQUIRED)
+find_package (Threads)
+include_directories(${PYTHON_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+
+add_library(kernels SHARED kernels.cpp)
+set_target_properties(kernels PROPERTIES PREFIX "")
+target_link_libraries (kernels
+    boost_python
+    ${PYTHON_LIBRARIES}
+    ${Boost_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
+    PBE
+)
+target_link_openfoam_libraries(kernels compressibleTwoPhaseSystem
+  compressibleEulerianInterfacialModels compressibleTurbulenceModels
+  incompressibleTurbulenceModels phaseCompressibleTurbulenceModels
+fvOptions)

--- a/src/PBESystem/bindings/CMakeLists.txt
+++ b/src/PBESystem/bindings/CMakeLists.txt
@@ -1,6 +1,5 @@
 find_package(PythonLibs 2)
 find_package(Boost COMPONENTS python REQUIRED)
-find_package (Threads)
 include_directories(${PYTHON_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 add_library(kernels SHARED kernels.cpp)
@@ -9,7 +8,6 @@ target_link_libraries (kernels
     boost_python
     ${PYTHON_LIBRARIES}
     ${Boost_LIBRARIES}
-    ${CMAKE_THREAD_LIBS_INIT}
     PBE
 )
 target_link_openfoam_libraries(kernels compressibleTwoPhaseSystem

--- a/src/PBESystem/bindings/kernels.cpp
+++ b/src/PBESystem/bindings/kernels.cpp
@@ -1,0 +1,12 @@
+#include <boost/python.hpp>
+#include "../breakupKernels/CoulaloglouTavlarides.H"
+
+BOOST_PYTHON_MODULE(kernels)
+{
+    using namespace boost::python;
+    using Foam::scalar;
+
+    class_<Foam::breakupKernels::CoulaloglouTavlaridesImp>("CoulaloglouTavlaridesImp"
+                                     , init<scalar, scalar, scalar, scalar>())
+            .def("S", &Foam::breakupKernels::CoulaloglouTavlaridesImp::S);
+}


### PR DESCRIPTION
This is the python 2 binding for the CT breakup kernel. If it looks ok, I will add the rest.
This will produce a library `kernels.so`, which can then be imported in python.
Example usage in a notebook:

``` python
import kernels
import numpy as np
from matplotlib import pyplot as plt
%matplotlib inline

ct = kernels.CoulaloglouTavlaridesImp(0.00487, 0.008, 0.0, 0.047)
rho_d = 5
epsilon = 3

X = np.linspace(0,10)
Y = [ct.S(x, rho_d, epsilon) for x in X]

plt.plot(X,Y)
```

Note that the OF environment variables should be available.
