### PR TITLE
Python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ include_directories ("$ENV{FOAM_SRC}/finiteVolume/lnInclude")
 set_source_files_properties(filename.c PROPERTIES LANGUAGE CXX )
 
 #gtest for testing
-add_subdirectory(ext/googletest/)
+
 #find_package(GTest REQUIRED)
 #include_directories(${GTEST_INCLUDE_DIRS})
 #find_package(Boost REQUIRED)
@@ -84,13 +84,21 @@ add_subdirectory(ext/googletest/)
 add_subdirectory(src/PBESystem)
 add_subdirectory(applications/PBEFoam)
 
+set(BUILD_TESTS false CACHE BOOL "Build tests")
+set(BUILD_BINDINGS false CACHE BOOL "Build python bindings")
+set(BUILD_BENCHMARKS false CACHE BOOL "Build benchmarks")
 
 ##unit tests
-#find_package (Threads)
-#add_subdirectory(tests)
+if (BUILD_TESTS)
+    add_subdirectory(ext/googletest/)
+    find_package (Threads)
+    add_subdirectory(tests)
+endif()
 
 ##benchmarks
-#set(CMAKE_BUILD_TYPE Release)
-add_subdirectory(ext/benchmark)
-set(GBENCH_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/ext/benchmark/include)
-add_subdirectory(benchmarks)
+if (BUILD_BENCHMARKS)
+    add_subdirectory(ext/benchmark)
+    set(GBENCH_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/ext/benchmark/include)
+    add_subdirectory(benchmarks)
+endif()
+

--- a/benchmarks/breakup.cpp
+++ b/benchmarks/breakup.cpp
@@ -4,8 +4,7 @@
 #include "breakupKernels/CoulaloglouTavlarides.H"
 
 static void binaryBreakup(benchmark::State& state) {
-    Foam::dimensionedScalar xi(
-                "xi", Foam::dimensionSet(0, 3, 0, 0, 0), 6);
+    Foam::scalar xi = 6.;
 
     Foam::breakupKernels::binaryBreakupImpl kernel;
 
@@ -16,10 +15,9 @@ static void binaryBreakup(benchmark::State& state) {
 BENCHMARK(binaryBreakup);
 
 static void noBreakup(benchmark::State& state) {
-    Foam::dimensionedScalar xi(
-                "xi", Foam::dimensionSet(0, 3, 0, 0, 0), 6);
+    Foam::scalar xi = 6.;
 
-    Foam::breakupKernels::binaryBreakupImpl kernel;
+    Foam::breakupKernels::noBreakupImpl kernel;
 
     while (state.KeepRunning())
         kernel.S(xi);

--- a/src/PBESystem/CMakeLists.txt
+++ b/src/PBESystem/CMakeLists.txt
@@ -59,5 +59,6 @@ target_link_libraries(PBE ${GSL_LIBRARIES} ${Boost_LIBRARIES})
 set_target_properties (PBE PROPERTIES LIBRARY_OUTPUT_DIRECTORY
   "$ENV{FOAM_USER_LIBBIN}")
 
-
-add_subdirectory(bindings)
+if (BUILD_BINDINGS)
+    add_subdirectory(bindings)
+endif()

--- a/src/PBESystem/bindings/kernels.cpp
+++ b/src/PBESystem/bindings/kernels.cpp
@@ -1,6 +1,10 @@
 #include <boost/python.hpp>
 #include "../breakupKernels/CoulaloglouTavlarides.H"
+#include "../breakupKernels/binaryBreakup.H"
+#include "../breakupKernels/noBreakup.H"
 #include "../coalescenceKernels/CoulaloglouTavlarides.H"
+#include "../coalescenceKernels/constantCoalescence.H"
+#include "../coalescenceKernels/noCoalescence.H"
 
 BOOST_PYTHON_MODULE(kernels)
 {
@@ -12,8 +16,25 @@ BOOST_PYTHON_MODULE(kernels)
                 init<scalar, scalar, scalar, scalar>())
             .def("S", &Foam::breakupKernels::CoulaloglouTavlaridesImp::S);
 
+    class_<Foam::breakupKernels::binaryBreakupImpl>(
+                "BinaryBreakup")
+            .def("S", &Foam::breakupKernels::binaryBreakupImpl::S);
+
+    class_<Foam::breakupKernels::noBreakupImpl>(
+                "NoBreakup")
+            .def("S", &Foam::breakupKernels::noBreakupImpl::S);
+
     class_<Foam::coalescenceKernels::CoulaloglouTavlaridesCImpl>(
                 "CoulaloglouTavlaridesCoalescence",
                 init<scalar, scalar, scalar, scalar>())
             .def("S", &Foam::coalescenceKernels::CoulaloglouTavlaridesCImpl::S);
+
+    class_<Foam::coalescenceKernels::constantCoalescenceImpl>(
+                "ConstantCoalescence",
+                init<scalar>())
+            .def("S", &Foam::coalescenceKernels::constantCoalescenceImpl::S);
+
+    class_<Foam::coalescenceKernels::noCoalescenceImpl>(
+                "NoCoalescence")
+            .def("S", &Foam::coalescenceKernels::noCoalescenceImpl::S);
 }

--- a/src/PBESystem/bindings/kernels.cpp
+++ b/src/PBESystem/bindings/kernels.cpp
@@ -1,12 +1,19 @@
 #include <boost/python.hpp>
 #include "../breakupKernels/CoulaloglouTavlarides.H"
+#include "../coalescenceKernels/CoulaloglouTavlarides.H"
 
 BOOST_PYTHON_MODULE(kernels)
 {
     using namespace boost::python;
     using Foam::scalar;
 
-    class_<Foam::breakupKernels::CoulaloglouTavlaridesImp>("CoulaloglouTavlaridesBreakup"
-                                     , init<scalar, scalar, scalar, scalar>())
+    class_<Foam::breakupKernels::CoulaloglouTavlaridesImp>(
+                "CoulaloglouTavlaridesBreakup",
+                init<scalar, scalar, scalar, scalar>())
             .def("S", &Foam::breakupKernels::CoulaloglouTavlaridesImp::S);
+
+    class_<Foam::coalescenceKernels::CoulaloglouTavlaridesCImpl>(
+                "CoulaloglouTavlaridesCoalescence",
+                init<scalar, scalar, scalar, scalar>())
+            .def("S", &Foam::coalescenceKernels::CoulaloglouTavlaridesCImpl::S);
 }

--- a/src/PBESystem/bindings/kernels.cpp
+++ b/src/PBESystem/bindings/kernels.cpp
@@ -6,7 +6,7 @@ BOOST_PYTHON_MODULE(kernels)
     using namespace boost::python;
     using Foam::scalar;
 
-    class_<Foam::breakupKernels::CoulaloglouTavlaridesImp>("CoulaloglouTavlaridesImp"
+    class_<Foam::breakupKernels::CoulaloglouTavlaridesImp>("CoulaloglouTavlaridesBreakup"
                                      , init<scalar, scalar, scalar, scalar>())
             .def("S", &Foam::breakupKernels::CoulaloglouTavlaridesImp::S);
 }

--- a/src/PBESystem/breakupKernels/binaryBreakup.C
+++ b/src/PBESystem/breakupKernels/binaryBreakup.C
@@ -48,8 +48,8 @@ binaryBreakup::binaryBreakup
 {
 }
 
-dimensionedScalar binaryBreakupImpl::S(const dimensionedScalar &xi) const {
-    return dimensionedScalar("S", dimless / dimTime, pow(xi.value(), 2));
+scalar binaryBreakupImpl::S(scalar xi) const {
+    return pow(xi, 2);
 }
 
 } //End namespace breakupKernels

--- a/src/PBESystem/breakupKernels/binaryBreakup.H
+++ b/src/PBESystem/breakupKernels/binaryBreakup.H
@@ -46,7 +46,7 @@ namespace breakupKernels
 class binaryBreakupImpl
 {
 public:
-    dimensionedScalar S(const dimensionedScalar& xi) const;
+    scalar S(scalar xi) const;
 };
 
 class binaryBreakup
@@ -65,7 +65,7 @@ class binaryBreakup
   virtual ~binaryBreakup() = default;
 
   scalar S(const dimensionedScalar &xi, label celli) const override {
-      return impl_.S(xi).value();
+      return impl_.S(xi.value());
   }
 
 private:

--- a/src/PBESystem/breakupKernels/noBreakup.C
+++ b/src/PBESystem/breakupKernels/noBreakup.C
@@ -48,9 +48,9 @@ noBreakup::noBreakup
 {
 }
 
-dimensionedScalar noBreakupImpl::S(const dimensionedScalar &xi) const
+scalar noBreakupImpl::S(scalar xi) const
 {
-    return dimensionedScalar("S", dimless / dimTime, 0);
+    return 0.;
 }
 
 } //End namespace breakupKernels

--- a/src/PBESystem/breakupKernels/noBreakup.H
+++ b/src/PBESystem/breakupKernels/noBreakup.H
@@ -46,7 +46,7 @@ namespace breakupKernels
 class noBreakupImpl
 {
 public:
-    dimensionedScalar S(const dimensionedScalar& xi) const;
+    scalar S(scalar xi) const;
 };
 
 class noBreakup
@@ -65,7 +65,7 @@ public:
   virtual ~noBreakup() = default;
 
   scalar S(const dimensionedScalar &xi, label celli) const override {
-      return impl_.S(xi).value();
+      return impl_.S(xi.value());
   }
 
 private:


### PR DESCRIPTION
Adding python bindings for the rest of the kernels.

Note that these are based on the *Impl classes, which do not share a common base class. To have that in python,
- either the *Impl classes should also have a common base class. Then the hierarchy will resemble a factory even more closely, however performance may be affected.
- or the bindings should be written for the actual kernels instead. However, that will require bindings for the OF classes, which is going to be a lot more involved.
